### PR TITLE
Add `ParseError` with range information for error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "TSPL"
-version = "0.0.10"
+version = "0.0.12"
 dependencies = [
  "highlight_error",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "TSPL"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "highlight_error",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "TSPL"
-version = "0.0.12"
+version = "0.0.13"
 authors = ["Victor Taelin <victor.taelin@gmail.com>"]
 edition = "2021"
 description = "The Simplest Parser Library"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,12 @@ impl<'a> From<ParseError> for String {
   }
 }
 
+impl<'a> std::fmt::Display for ParseError {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    self.message.fmt(f)
+  }
+}
+
 pub trait Parser<'i> {
 
   fn input(&mut self) -> &'i str;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ pub trait Parser<'i> {
   fn expected_and<T>(&mut self, exp: &str, msg: &str) -> Result<T, ParseError> {
     let span = (*self.index(), *self.index() + 1);
     let ctx = highlight_error(span.0, span.1, self.input());
-    let msg = format!("\x1b[1mPARSE_ERROR\n- expected: \x1b[0m{}\x1b[1m\n- detected:\n\x1b[0m{}\x1b[1m\n - info:\n\x1b[0m{}", exp, ctx, msg);
+    let msg = format!("\x1b[1mPARSE_ERROR\n- information: \x1b[0m{}\x1b[1m\n- expected: \x1b[0m{}\x1b[1m\n- detected:\n\x1b[0m{}\x1b[1m\n ", msg, exp, ctx);
     Err(ParseError::new(span, msg))
   }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -235,7 +235,7 @@ pub trait Parser<'i> {
   }
 
   /// Parses a quoted character, like 'x'.
-  fn parse_quoted_char(&mut self) -> Result<char, String> {
+  fn parse_quoted_char(&mut self) -> Result<char, ParseError> {
     self.skip_trivia();
     self.consume("'")?;
     let chr = self.parse_char()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,17 +44,19 @@ impl ParseError {
   }
 }
 
-impl<'a> From<ParseError> for String {
+impl From<ParseError> for String {
   fn from(val: ParseError) -> Self {
     val.message
   }
 }
 
-impl<'a> std::fmt::Display for ParseError {
+impl std::fmt::Display for ParseError {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     self.message.fmt(f)
   }
 }
+
+impl std::error::Error for ParseError {}
 
 pub trait Parser<'i> {
 


### PR DESCRIPTION
This PR changes parsing function results to explicitly return error range information, so code analyzers (like language servers) are capable of reliably reporting parsing error locations.

More changes will probably be needed in the future - parsed terms should also know the range they represent in the code, though I'm currently unsure how to add this to TSPL without complicating it too much.

Version has been bumped by this PR, so we'll need to publish it to crates-io.